### PR TITLE
fix: Update types export in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,12 @@
   "license": "MIT",
   "author": "Damien Seguin (https://github.com/dmnsgn)",
   "type": "module",
-  "exports": "./index.js",
+  "exports": {
+    ".": {
+      "types": "./types/index.d.ts",
+      "default": "./index.js"
+    }
+  },
   "main": "index.js",
   "types": "types/index.d.ts",
   "scripts": {


### PR DESCRIPTION
This addition to package.json appeases the arethetypeswrong CLI tool,
and so should hopefully export types in a way that newer versions of tsc
are happy with.

Note that I had to install jsdoc-tsimport-plugin as a dev-dependency in
order to get `npm run build` to complete, though I didn't include this
in the package.json changes.

I referenced this blog post when figuring out the correct values for the
exports object:

https://www.kravchyk.com/typescript-npm-package-json-exports/

When I run the `attw` command-line tool, I get the following output:

```
[mag@mac primitive-geometry]% attw --pack .

primitive-geometry v2.10.0

⚠️ A require call resolved to an ESM JavaScript file, which is an error in Node and some bundlers. CommonJS consumers will need to use a dynamic import. https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/docs/problems/CJSResolvesToESM.md

┌───────────────────┬──────────────────────────────┐
│                   │ "primitive-geometry"         │
├───────────────────┼──────────────────────────────┤
│ node10            │ 🟢                           │
├───────────────────┼──────────────────────────────┤
│ node16 (from CJS) │ ⚠️ ESM (dynamic import only) │
├───────────────────┼──────────────────────────────┤
│ node16 (from ESM) │ 🟢 (ESM)                     │
├───────────────────┼──────────────────────────────┤
│ bundler           │ 🟢                           │
└───────────────────┴──────────────────────────────┘
```

The warning is only for the fact that primitive-geometry doesn't support
importing as CommonJS module.

Closes https://github.com/dmnsgn/primitive-geometry/issues/18.